### PR TITLE
feat: Refresh Token Endpoint

### DIFF
--- a/app/dto/v1/authentication_dto.py
+++ b/app/dto/v1/authentication_dto.py
@@ -215,3 +215,16 @@ class LogoutResponseDto(BaseModel):
     status_code: int = Field(default=200, examples=[200])
     message: str = Field(default="Logout success", examples=["Logout success"])
     data: dict = Field(default={}, examples=[{}])
+
+
+# +++++++++++++++++++++++++== refresh token ++++++++++++++++++++++++++++++++++
+class RefreshTokenResponseDto(BaseModel):
+    """
+    Refresh token dto
+    """
+
+    status_code: int = Field(default=200, examples=[200])
+    message: str = Field(
+        default="Tokens refresh successful", examples=["Tokens refresh successful"]
+    )
+    data: AccessTokenDto

--- a/app/route/v1/auth_route.py
+++ b/app/route/v1/auth_route.py
@@ -14,9 +14,10 @@ from app.dto.v1.authentication_dto import (
     AuthenticateUserRequestDto,
     AuthenticateUserResponseDto,
     LogoutResponseDto,
+    RefreshTokenResponseDto,
 )
 from app.database.session import get_async_session
-from app.core.security import validate_logout_status
+from app.core.security import validate_logout_status, get_refresh_token_header
 
 logger = create_logger("Auth Route")
 
@@ -101,3 +102,31 @@ async def logout(
         409 conflict
     """
     return await authentication_service.logout(request=request, session=session)
+
+
+@auth_router.post(
+    "/refresh-tokens",
+    status_code=status.HTTP_200_OK,
+    responses=responses,
+    response_model=RefreshTokenResponseDto,
+    dependencies=[Depends(get_refresh_token_header)],
+)
+async def refresh_tokens(
+    request: Request,
+    response: Response,
+    session: typing.Annotated[AsyncSession, Depends(get_async_session)],
+) -> typing.Union[RefreshTokenResponseDto, None]:
+    """
+    Refreshes tokens.
+
+    Return:
+        Success message upon successful refresh
+    Raises:
+        401 Unauthorized.
+        422 Validation Error.
+        500 Internal server error
+        409 conflict
+    """
+    return await authentication_service.refresh_token(
+        request=request, session=session, response=response
+    )

--- a/app/tests/v1/auth/test_e2e_refresh_tokens.py
+++ b/app/tests/v1/auth/test_e2e_refresh_tokens.py
@@ -1,0 +1,157 @@
+"""
+Test refresh token module
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from app.tests.v1.auth import login_register_input
+
+
+class TestRefreshTokens:
+    """
+    Tests refresh token class
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_when_missing_refresh_token_header_returns_401(
+        self, test_setup: None, client: AsyncClient
+    ) -> None:
+        """
+        Tests refresh token when x-refresh-token header missing
+        """
+        response = await client.post(url="/api/v1/auth/refresh-tokens")
+
+        assert response.status_code == 422
+
+        data: dict = response.json()
+
+        assert data["message"] == "Validation Error."
+        assert data["data"]["msg"] == "Field required"
+
+    @pytest.mark.asyncio
+    async def test_b_when_refresh_token_header_uses_access_token_returns_401(
+        self, test_setup: None, client: AsyncClient
+    ) -> None:
+        """
+        Tests refresh token when x-refresh-token header missing
+        """
+        login_payload = {
+            "password": login_register_input.get("password"),
+            "email": login_register_input.get("email"),
+            "session_id": "000000000000-0000-0100-0000-01010001",
+        }
+        # register
+        response = await client.post(
+            url="/api/v1/auth/register", json=login_register_input
+        )
+        assert response.status_code == 201
+
+        # login
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        # get access token
+        access_token = data["data"]["access_token"]["token"]
+
+        # send access token as refresh token
+        response = await client.post(
+            url="/api/v1/auth/refresh-tokens", headers={"X-REFRESH-TOKEN": access_token}
+        )
+
+        assert response.status_code == 401
+
+        data: dict = response.json()
+
+        assert data["message"] == "Invalid token type"
+
+    @pytest.mark.asyncio
+    async def test_c_full_refresh_token_flow(
+        self, test_setup: None, client: AsyncClient
+    ) -> None:
+        """
+        Tests when cannot reuse access and refresh token after refresh
+        """
+        login_payload = {
+            "password": login_register_input.get("password"),
+            "email": login_register_input.get("email"),
+            "session_id": "000000000000-0000-0100-0000-01011001",
+        }
+        # register
+        response = await client.post(
+            url="/api/v1/auth/register", json=login_register_input
+        )
+        assert response.status_code == 201
+
+        # login
+        login_response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert login_response.status_code == 200
+
+        data: dict = login_response.json()
+
+        # get access token
+        old_access_token = data["data"]["access_token"]["token"]
+        # get refresh token
+        refresh_token = login_response.headers.get("x-refresh-token")
+
+        # refresh tokens
+        # should return 200
+        refresh_response = await client.post(
+            url="/api/v1/auth/refresh-tokens",
+            headers={"X-REFRESH-TOKEN": refresh_token},
+        )
+
+        assert refresh_response.status_code == 200
+
+        data: dict = refresh_response.json()
+
+        assert data["message"] == "Tokens refresh successful"
+        # get new access token
+        new_access_token = data["data"]["token"]
+
+        # get refresh token
+        new_refresh_token = refresh_response.headers.get("x-refresh-token")
+
+        # access logout route with old access token
+        # should return 401
+        logout_response = await client.post(
+            url="/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {old_access_token}"},
+        )
+
+        assert logout_response.status_code == 401
+
+        data: dict = logout_response.json()
+
+        assert data["status_code"] == 401
+        assert data["message"] == "Invalid or expired session"
+
+        # use new access token to access logout route
+        # should revoke access and refresh tokens successfully
+        logout2_response = await client.post(
+            url="/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {new_access_token}"},
+        )
+
+        assert logout2_response.status_code == 200
+
+        data: dict = logout2_response.json()
+
+        assert data["status_code"] == 200
+
+        # refresh tokens with revoked new_refresh_token due to logout
+        # should return 401
+        response = await client.post(
+            url="/api/v1/auth/refresh-tokens",
+            headers={"X-REFRESH-TOKEN": new_refresh_token},
+        )
+
+        assert response.status_code == 401
+
+        data: dict = response.json()
+
+        assert data["message"] == "Invalid refresh token"


### PR DESCRIPTION


#### **Endpoint**

```http
POST /api/v1/auth/refresh-tokens
```

#### **Summary**

This PR implements the `refresh-tokens` endpoint to securely rotate access and refresh tokens. When a valid refresh token is sent via the `x-refresh-token` header, the previous access and refresh tokens are invalidated by marking the associated `jti` (JWT ID) as **logged out**, and a new token pair is issued.

---

#### ✅ Success Behavior

* When a valid `x-refresh-token` is provided:

  * The server verifies the refresh token.
  * Logs out the current session (by jti).
  * Generates a new token pair.
  * Returns:

    ```json
    {
      "status_code": 200,
      "message": "Tokens refresh successful",
      "data": {
        "token": "<new_access_token>",
        "expire_at": <timestamp>
      }
    }
    ```
  * New refresh token is returned in response **headers**:

    ```
    x-refresh-token: <new_refresh_token>
    ```

---

#### ❌ Failure Behavior

* When the `x-refresh-token` header is **missing**:

  * Returns:

    ```json
    {
      "status_code": 422,
      "message": "Validation Error.",
      "data": {
        "msg": "Missing Field",
        "loc": "x-refresh-token"
      }
    }
    ```

* When the token is invalid or expired:

  * Returns appropriate `401 Unauthorized` or `403 Forbidden` error.

---

#### 🔐 Security Notes

* Session `jti` is marked as invalidated after refresh.
* Tokens are rotated; reuse of old refresh tokens is prevented.
* HTTP-only and secure headers are used (production assumption).
* Strong JWT signing (HS256 or better).
* Refresh token is sent in `x-refresh-token` **header**, not body.

---

#### 📋 Headers Example (Response)

```http
x-refresh-token: <new_refresh_token>
content-type: application/json
x-frame-options: DENY
x-content-type-options: nosniff
strict-transport-security: max-age=31536000; includeSubDomains; preload
referrer-policy: strict-origin-when-cross-origin
```

---

#### 🧪 cURL Example

```bash
curl -X 'POST' \
  'http://127.0.0.1:7000/api/v1/auth/refresh-tokens' \
  -H 'accept: application/json' \
  -H 'x-refresh-token: <valid_refresh_token>' \
  -d ''
```