### PR TITLE
feat: Implement Media Upload Endpoints (Files, Images, Videos)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -46,3 +46,7 @@ CELERY_RESULT_BACKEND='db+postgresql://username:password@localhost/test'
 CELERY_RESULT_BACKEND_TEST= "db+sqlite:///:memory:"
 
 REDIS_URL="redis://127.0.0.1:6379/0"
+
+CLOUDINARY_API_KEY="somekey"
+CLOUDINARY_API_SECRET="somesecret"
+CLOUDINARY_API_NAME="somename"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -51,6 +51,10 @@ class Settings(BaseSettings):
     celery_result_backend: str
     celery_result_backend_test: str
 
+    cloudinary_api_key: str
+    cloudinary_api_secret: str
+    cloudinary_api_name: str
+
     redis_url: str
 
     model_config: SettingsConfigDict = {  # type: ignore

--- a/app/dto/v1/media_upload_dto.py
+++ b/app/dto/v1/media_upload_dto.py
@@ -1,0 +1,23 @@
+"""
+Media upload DTO
+"""
+
+from typing import Dict, Optional
+from pydantic import BaseModel, Field
+
+
+# +++++++++++++++++++++++++++++++++++++++  message mdeia upload +++++++++++++++++++++++++++++++++++++++++
+# media upload schema
+class UploadMessageMediaResponseDto(BaseModel):
+    """
+    Media upload schema
+    """
+
+    message: str = Field(
+        default="media uploaded successfully",
+        examples=["media uploaded successfully"],
+    )
+    status_code: int = Field(default=201, examples=[201])
+    data: Dict[str, Optional[str]] = Field(
+        examples=[{"media_url": "https://media_url.com/image", "media_type": "image"}]
+    )

--- a/app/route/v1/__init__.py
+++ b/app/route/v1/__init__.py
@@ -1,9 +1,15 @@
+"""
+Router Init
+"""
+
 from fastapi import APIRouter
 
 from app.route.v1.auth_route import auth_router
 from app.route.v1.direct_message_route import direct_message_router
+from app.route.v1.media_upload_route import media_upload_router
 
 api_version_one = APIRouter(prefix="/api/v1")
 
 api_version_one.include_router(auth_router)
 api_version_one.include_router(direct_message_router)
+api_version_one.include_router(media_upload_router)

--- a/app/route/v1/media_upload_route.py
+++ b/app/route/v1/media_upload_route.py
@@ -1,0 +1,122 @@
+"""
+Media upload Route Module
+"""
+
+import typing
+from fastapi import APIRouter, status, Request, Depends, UploadFile
+
+from app.utils.responses import responses
+from app.service.v1.media_upload_service import media_upload_service
+from app.dto.v1.media_upload_dto import UploadMessageMediaResponseDto
+from app.core.security import validate_logout_status
+
+
+media_upload_router = APIRouter(prefix="/media-uploads", tags=["MEDIA UPLOAD"])
+
+
+@media_upload_router.post(
+    "/images",
+    status_code=status.HTTP_201_CREATED,
+    responses=responses,
+    response_model=UploadMessageMediaResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def upload_images(
+    request: Request, media_to_upload: UploadFile
+) -> typing.Optional[UploadMessageMediaResponseDto]:
+    """
+    Uploads images.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await media_upload_service.validate_media_and_upload(
+        media_to_upload=media_to_upload, request=request, file_type="image"
+    )
+
+
+@media_upload_router.post(
+    "/videos",
+    status_code=status.HTTP_201_CREATED,
+    responses=responses,
+    response_model=UploadMessageMediaResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def upload_videos(
+    request: Request, media_to_upload: UploadFile
+) -> typing.Optional[UploadMessageMediaResponseDto]:
+    """
+    Uploads images.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await media_upload_service.validate_media_and_upload(
+        media_to_upload=media_to_upload, request=request, file_type="video"
+    )
+
+
+@media_upload_router.post(
+    "/audios",
+    status_code=status.HTTP_201_CREATED,
+    responses=responses,
+    response_model=UploadMessageMediaResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def upload_audios(
+    request: Request, media_to_upload: UploadFile
+) -> typing.Optional[UploadMessageMediaResponseDto]:
+    """
+    Uploads audios.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await media_upload_service.validate_media_and_upload(
+        media_to_upload=media_to_upload, request=request, file_type="audio"
+    )
+
+
+@media_upload_router.post(
+    "/files",
+    status_code=status.HTTP_201_CREATED,
+    responses=responses,
+    response_model=UploadMessageMediaResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def upload_files(
+    request: Request, media_to_upload: UploadFile
+) -> typing.Optional[UploadMessageMediaResponseDto]:
+    """
+    Uploads files.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await media_upload_service.validate_media_and_upload(
+        media_to_upload=media_to_upload, request=request, file_type="file"
+    )

--- a/app/service/v1/media_upload_service.py
+++ b/app/service/v1/media_upload_service.py
@@ -1,0 +1,266 @@
+"""
+MediaUploadService module
+"""
+
+import typing
+from asyncio import to_thread
+from uuid import uuid4
+import re
+import os
+from io import BytesIO
+
+
+from fastapi import HTTPException, UploadFile, Request
+import cloudinary
+import cloudinary.uploader
+from cloudinary.exceptions import Error as CloudinaryError
+from PIL import Image
+
+from app.utils.task_logger import create_logger
+from app.core.config import settings
+from app.dto.v1.media_upload_dto import UploadMessageMediaResponseDto
+
+
+logger = create_logger(":: MediaUploadService Service ::")
+
+
+class MediaUploadService:
+    """
+    DirectMessage Service
+    """
+
+    def __init__(self) -> None:
+        """
+        Constructor
+        """
+        # Configure Cloudinary
+        cloudinary.config(
+            cloud_name=settings.cloudinary_api_name,
+            api_key=settings.cloudinary_api_key,
+            api_secret=settings.cloudinary_api_secret,
+            secured=True,
+        )
+
+        self.image_content_types = {
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/webp",
+            "image/svg+xml",
+            "image/bmp",
+            "image/tiff",
+            "image/gif",
+        }
+        self.video_content_types = {
+            "video/mp4",
+            "video/webm",
+            "video/ogg",
+            "video/quicktime",
+            "audio/mpeg",
+            "audio/ogg",
+            "audio/webm",
+            "audio/mp4",
+            "audio/m4a",
+            # "audio/x-ms-wma",
+            # "audio/flac",
+            # "audio/3gpp",
+            # "audio/amr",
+        }
+
+        self.file_content_types = {
+            "text/csv",
+            "application/json",
+            "application/xml",
+            "application/x-yaml",
+            "application/zip",
+            "application/gzip",
+            "application/x-7z-compressed",
+            "application/pdf",
+            "application/msword",
+            "application/vnd.ms-excel",
+            "text/plain",
+            "application/vnd.ms-powerpoint",
+        }
+
+    async def validate_media_and_upload(
+        self, request: Request, media_to_upload: UploadFile, file_type: str
+    ) -> typing.Union[UploadMessageMediaResponseDto, None]:
+        """
+        Validates media file and uploads to cloud
+        """
+        claims: dict = request.state.claims
+        current_user_id = claims.get("user_id")
+        if file_type == "image":
+            if media_to_upload.content_type not in self.image_content_types:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Unsupported content_type. content_type must be one of {self.image_content_types}",
+                )
+            if media_to_upload.size and media_to_upload.size > 4 * 1024 * 1024:  # 4MB
+                raise HTTPException(
+                    status_code=400, detail="FIle size exceeds the limit of 4MB"
+                )
+            if not media_to_upload.size:
+                raise HTTPException(
+                    status_code=400, detail="Image is without size. Invalid image file"
+                )
+
+            photo_name = f"{uuid4()}_{current_user_id}"
+            if media_to_upload.filename:
+                photo_name, _ = os.path.splitext(media_to_upload.filename)
+                photo_name = re.sub(r"[^\w\-_\.]", "_", photo_name)
+                photo_name = f"{photo_name}_{current_user_id}"
+
+            media_url = await self.upload_to_cloudinary(
+                file=media_to_upload,
+                folder="message-images",
+                file_name=photo_name,
+                file_type=file_type,
+                resource_type="image",
+            )
+
+            return UploadMessageMediaResponseDto(
+                data={"media_url": media_url, "media_type": file_type}
+            )
+        if file_type == "video" or file_type == "audio":
+            if media_to_upload.content_type not in self.video_content_types:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Unsupported content_type. content_type must be one of {self.video_content_types}",
+                )
+            if media_to_upload.size and media_to_upload.size > 5 * 1024 * 1024:  # 5MB
+                raise HTTPException(
+                    status_code=400, detail="FIle size exceeds the limit of 5MB"
+                )
+            if not media_to_upload.size:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{file_type} is without size. Invalid {file_type} file",
+                )
+
+            video_name = f"{uuid4()}_{current_user_id}"
+            if media_to_upload.filename:
+                video_name, _ = os.path.splitext(media_to_upload.filename)
+                video_name = re.sub(r"[^\w\-_\.]", "_", video_name)
+                video_name = f"{video_name}_{current_user_id}"
+
+            media_url = await self.upload_to_cloudinary(
+                file=media_to_upload,
+                folder=f"message-{file_type}s",
+                file_name=video_name,
+                file_type=file_type,
+                resource_type="video",
+            )
+
+            return UploadMessageMediaResponseDto(
+                data={"media_url": media_url, "media_type": file_type}
+            )
+
+        if not media_to_upload.content_type:
+            raise HTTPException(status_code=400, detail="Content type missing")
+        if media_to_upload.content_type not in self.file_content_types:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported content_type. content_type must be one of {self.file_content_types}",
+            )
+        if media_to_upload.size and media_to_upload.size > 1 * 1024 * 1024:  # 1MB
+            raise HTTPException(
+                status_code=400, detail="FIle size exceeds the limit of 1MB"
+            )
+        if not media_to_upload.size:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{file_type} is without size. Invalid {file_type} file",
+            )
+
+        file_name = f"{uuid4()}_{current_user_id}"
+        if media_to_upload.filename:
+            file_name, _ = os.path.splitext(media_to_upload.filename)
+            file_name = re.sub(r"[^\w\-_\.]", "_", file_name)
+            file_name = f"{file_name}_{current_user_id}"
+
+        media_url = await self.upload_to_cloudinary(
+            file=media_to_upload,
+            folder=f"message-{file_type}s",
+            file_name=file_name,
+            file_type=file_type,
+            resource_type="raw",
+        )
+
+        return UploadMessageMediaResponseDto(
+            data={"media_url": media_url, "media_type": file_type}
+        )
+
+    async def upload_to_cloudinary(
+        self,
+        file: UploadFile,
+        folder: str,
+        file_name: str,
+        file_type: str,
+        resource_type: str,
+    ) -> typing.Union[str, None]:
+        """
+        Uploads a file to Cloudinary and returns the direct download URL.
+
+        Args:
+            file (UploadFile): File to upload
+            folder (str): Cloudinary folder to store the file in. videos or images.
+            resource_type (str): The name of the resource. e.g (video, audio, image)
+                Note: Use the video resource type for all video assets as well as for audio files, such as .mp3.
+
+        Returns:
+            str: Direct download URL of the uploaded file
+        """
+        product_id_prefix = f"{file_type}s"
+
+        try:
+            result = await to_thread(
+                cloudinary.uploader.upload,
+                file=file.file,
+                asset_folder=folder,
+                resource_type=resource_type,
+                public_id=file_name,
+                product_id_prefix=product_id_prefix,
+                use_filename=True,
+                use_filename_as_display_name=True,
+                unique_filename=False,
+                overwrite=False,
+                eager=(
+                    []
+                    if file_type != "video"
+                    else [
+                        {
+                            "width": 720,  # Set a target width (or height if using scale)
+                            "crop": "scale",  # Scale to fit width, maintaining aspect ratio
+                            "quality": "auto",  # Apply the desired quality preset
+                            "format": "mp4",  # Ensure output is mp4 for broad compatibility
+                            "fetch_format": "auto",  # Auto-select format for delivery
+                        }
+                    ]
+                ),
+                eager_async=True,
+            )
+            # Get the file URL and append `fl_attachment` for direct download
+            return result.get("secure_url")
+        except CloudinaryError as exc:
+            logger.error("Error uploading file to cloudinary: %s", str(exc))
+            raise HTTPException(status_code=417, detail="File upload failed") from exc
+
+    async def compress_image(
+        self, upload_file: UploadFile, quality: int = 70
+    ) -> BytesIO:
+        """
+        Compresses images
+        """
+        image = Image.open(await upload_file.read())
+        buffer = BytesIO()
+
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+
+        image.save(buffer, format="JPEG", optimize=True, quality=quality)
+        buffer.seek(0)
+        return buffer
+
+
+media_upload_service = MediaUploadService()

--- a/app/tests/v1/media_upload/__init__.py
+++ b/app/tests/v1/media_upload/__init__.py
@@ -1,0 +1,6 @@
+register_input = {
+    "email": "jayson4@gtest.com",
+    "password": "Jayson1234#",
+    "confirm_password": "Jayson1234#",
+    "idempotency_key": "1asa5aaa9012-1234-2w3e-4r5t-6y7u8i9o",
+}

--- a/app/tests/v1/media_upload/test_e2e_file_upload.py
+++ b/app/tests/v1/media_upload/test_e2e_file_upload.py
@@ -1,0 +1,225 @@
+"""
+Test File upload message module
+"""
+
+from unittest.mock import patch
+import io
+import pytest
+from httpx import AsyncClient
+
+from app.tests.v1.direct_message import register_input
+
+
+class TestFileMediaUpload:
+    """
+    Test File Media upload route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_upload_File_successfully(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests user can upload File successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-00d0-0000-0000-00qde0001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.pdf",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content"
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/files",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "application/json"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 201
+                    data2: dict = response2.json()
+
+                    assert data2["message"] == "media uploaded successfully"
+                    assert (
+                        data2["data"]["media_url"] == "https://cloudinary.com/fake.pdf"
+                    )
+                    assert data2["data"]["media_type"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_b_when_invalid_content_type_returns_400(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests when invalid content type returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-0000-sas0-ss000sa1",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.pdf",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content"
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/files",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "application/none"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 400
+                    data2: dict = response2.json()
+
+                    assert data2["message"].startswith(
+                        "Unsupported content_type. content_type must be one of"
+                    )
+
+    @pytest.mark.asyncio
+    async def test_c_when_file_size_too_large_returns_400(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests when file size too large returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-wwww-0000-sssw0031",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.json",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content" * (2 * 1024 * 1024)
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/files",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "application/json"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 400
+                    data2: dict = response2.json()
+
+                    assert data2["message"].startswith(
+                        "FIle size exceeds the limit of 1MB"
+                    )

--- a/app/tests/v1/media_upload/test_e2e_image_upload.py
+++ b/app/tests/v1/media_upload/test_e2e_image_upload.py
@@ -1,0 +1,225 @@
+"""
+Test Media upload message module
+"""
+
+from unittest.mock import patch
+import io
+import pytest
+from httpx import AsyncClient
+
+from app.tests.v1.direct_message import register_input
+
+
+class TestImageMediaUpload:
+    """
+    Test Image Media upload route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_upload_image_successfully(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests user can upload image successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-0000-0000-00000001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.png",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content"
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/images",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "image/png"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 201
+                    data2: dict = response2.json()
+
+                    assert data2["message"] == "media uploaded successfully"
+                    assert (
+                        data2["data"]["media_url"] == "https://cloudinary.com/fake.png"
+                    )
+                    assert data2["data"]["media_type"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_b_when_invalid_content_type_returns_400(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests when invalid content type returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-0000-0000-ss000001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.png",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content"
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/images",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "image/none"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 400
+                    data2: dict = response2.json()
+
+                    assert data2["message"].startswith(
+                        "Unsupported content_type. content_type must be one of"
+                    )
+
+    @pytest.mark.asyncio
+    async def test_c_when_file_size_too_large_returns_400(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests when file size too large returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-0000-0000-ss000031",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.png",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content" * (5 * 1024 * 1024)
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/images",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "image/png"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 400
+                    data2: dict = response2.json()
+
+                    assert data2["message"].startswith(
+                        "FIle size exceeds the limit of 4MB"
+                    )

--- a/app/tests/v1/media_upload/test_e2e_video_upload.py
+++ b/app/tests/v1/media_upload/test_e2e_video_upload.py
@@ -1,0 +1,225 @@
+"""
+Test Video upload message module
+"""
+
+from unittest.mock import patch
+import io
+import pytest
+from httpx import AsyncClient
+
+from app.tests.v1.direct_message import register_input
+
+
+class TestVideoMediaUpload:
+    """
+    Test Video Media upload route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_upload_Video_successfully(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests user can upload Video successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-00d0-0000-0000-00000001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.mp4",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content"
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/videos",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "video/mp4"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 201
+                    data2: dict = response2.json()
+
+                    assert data2["message"] == "media uploaded successfully"
+                    assert (
+                        data2["data"]["media_url"] == "https://cloudinary.com/fake.mp4"
+                    )
+                    assert data2["data"]["media_type"] == "video"
+
+    @pytest.mark.asyncio
+    async def test_b_when_invalid_content_type_returns_400(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests when invalid content type returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-0000-0000-ss000sa1",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.mp4",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content"
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/videos",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "video/none"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 400
+                    data2: dict = response2.json()
+
+                    assert data2["message"].startswith(
+                        "Unsupported content_type. content_type must be one of"
+                    )
+
+    @pytest.mark.asyncio
+    async def test_c_when_file_size_too_large_returns_400(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests when file size too large returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00000sddeee0-0000-0000-0000-sssw0031",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                with patch(
+                    "app.service.v1.media_upload_service.MediaUploadService.upload_to_cloudinary",
+                    return_value="https://cloudinary.com/fake.mp4",
+                ):
+                    # register first user
+                    response0 = await client.post(
+                        url="/api/v1/auth/register", json=register_input
+                    )
+                    assert response0.status_code == 201
+
+                    # verify first user
+                    await client.patch(
+                        url="/api/v1/auth/verify-account",
+                        json={"email": register_input.get("email"), "code": "123456"},
+                    )
+
+                    # login first user
+                    response1 = await client.post(
+                        url="/api/v1/auth/login", json=login_payload
+                    )
+
+                    assert response1.status_code == 200
+
+                    data1: dict = response1.json()
+
+                    access_token = data1["data"]["access_token"]["token"]
+
+                    image_content = b"Image file content" * (6 * 1024 * 1024)
+                    image_file = io.BytesIO(image_content)
+
+                    response2 = await client.post(
+                        url="/api/v1/media-uploads/videos",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=[
+                            (
+                                ("media_to_upload"),
+                                ("photo1.png", image_file, "video/mp4"),
+                            )
+                        ],
+                    )
+
+                    assert response2.status_code == 400
+                    data2: dict = response2.json()
+
+                    assert data2["message"].startswith(
+                        "FIle size exceeds the limit of 5MB"
+                    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,9 @@ click==8.1.7
 click-didyoumean==0.3.1
 click-plugins==1.1.1
 click-repl==0.3.0
+cloudinary==1.44.0
 cryptography==43.0.1
+decorator==5.2.1
 Deprecated==1.2.18
 dnspython==2.6.1
 ecdsa==0.19.0
@@ -32,6 +34,8 @@ httpcore==1.0.5
 httpx==0.27.2
 humanize==4.11.0
 idna==3.10
+imageio==2.37.0
+imageio-ffmpeg==0.6.0
 iniconfig==2.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.4
@@ -39,9 +43,12 @@ kombu==5.4.2
 limits==5.2.0
 Mako==1.3.5
 MarkupSafe==2.1.5
+numpy==2.2.6
 packaging==24.1
 passlib==1.7.4
+pillow==11.2.1
 pluggy==1.5.0
+proglog==0.1.12
 prometheus_client==0.21.0
 prompt_toolkit==3.0.48
 psycopg2-binary==2.9.9
@@ -68,8 +75,10 @@ starlette==0.38.5
 tenacity==9.0.0
 tomli==2.0.1
 tornado==6.4.1
+tqdm==4.67.1
 typing_extensions==4.12.2
 tzdata==2024.2
+urllib3==2.4.0
 uvicorn==0.30.6
 vine==5.1.0
 watchdog==5.0.3


### PR DESCRIPTION

### 📌 Description

This PR adds three new endpoints to support uploading different media types — **files**, **images**, and **videos** — via `multipart/form-data`. The uploads are handled through Cloudinary (or other backend storage provider), and the response returns the secure URL and media type.

---

### ✅ Endpoints Implemented

#### 1. **Upload a File**

**`POST /api/v1/media-uploads/files`**

* Accepts general files (e.g., PDF, DOCX, TXT).
* Media type in response: `"files"`.

Example cURL:

```bash
curl -X 'POST' \
  'http://127.0.0.1:7000/api/v1/media-uploads/files' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: multipart/form-data' \
  -F 'media_to_upload=@CIT213.pdf;type=application/pdf'
```

---

#### 2. **Upload an Image**

**`POST /api/v1/media-uploads/images`**

* Accepts image files (e.g., PNG, JPG, JPEG).
* Converts uploaded file to image format.
* Media type in response: `"image"`.

Example cURL:

```bash
curl -X 'POST' \
  'http://127.0.0.1:7000/api/v1/media-uploads/images' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: multipart/form-data' \
  -F 'media_to_upload=@CIT213.pdf;type=image/png'
```

---

#### 3. **Upload a Video**

**`POST /api/v1/media-uploads/videos`**

* Accepts video files (e.g., MP4, MOV, AVI).
* Converts uploaded file to video format if necessary.
* Media type in response: `"video"`.

Example cURL:

```bash
curl -X 'POST' \
  'http://127.0.0.1:7000/api/v1/media-uploads/videos' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: multipart/form-data' \
  -F 'media_to_upload=@CIT213.pdf;type=video/mp4'
```

---

### 🧪 Response Format

Each endpoint returns:

```json
{
  "message": "media uploaded successfully",
  "status_code": 201,
  "data": {
    "media_url": "<cloudinary_url_with_extension>",
    "media_type": "<files | image | video>"
  }
}
```

---

### 🔒 Security

* All routes require **Bearer Token authentication**.
* Media file type is **validated** before upload.

---

### 🧩 TASKS

* [x] Add unit tests for upload routes
* [x] Add file size limit and validation

---
