### PR TITLE
feat:  Add Endpoint to Retrieve Paginated List of Chat Rooms (`GET /api/v1/rooms`)

### DIFF
--- a/app/dto/v1/room_dto.py
+++ b/app/dto/v1/room_dto.py
@@ -2,7 +2,7 @@
 Room DTOs
 """
 
-from typing import Annotated, Optional
+from typing import Annotated, Optional, List
 from pydantic import BaseModel, StringConstraints, Field, HttpUrl, ConfigDict
 
 
@@ -55,3 +55,21 @@ class CreateRoomResponseDto(BaseModel):
     )
     status_code: int = Field(default=201, examples=[201])
     data: RoomBaseDto
+
+
+# ++++++++++++++++++++++++++++ Retrieve rooms ++++++++++++++++++++++++++
+class RetrieveResponseDto(BaseModel):
+    """
+    Retrieve room
+    """
+
+    message: str = Field(
+        default="Rooms retrieved successfully.",
+        examples=["Rooms retrieved successfully."],
+    )
+    status_code: int = Field(default=201, examples=[200])
+    page: int = Field(examples=[1])
+    limit: int = Field(examples=[10])
+    total_pages: int = Field(examples=[1])
+    total_rooms: int = Field(examples=[10])
+    data: List[Optional[RoomBaseDto]]

--- a/app/route/v1/room_route.py
+++ b/app/route/v1/room_route.py
@@ -3,11 +3,15 @@ Room Route Module
 """
 
 import typing
-from fastapi import APIRouter, status, Request, Depends
+from fastapi import APIRouter, status, Request, Depends, Query
 
 from app.utils.responses import responses
 from app.service.v1.room_service import room_service, AsyncSession
-from app.dto.v1.room_dto import CreateRoomRequestDto, CreateRoomResponseDto
+from app.dto.v1.room_dto import (
+    CreateRoomRequestDto,
+    CreateRoomResponseDto,
+    RetrieveResponseDto,
+)
 from app.core.security import validate_logout_status
 from app.database.session import get_async_session
 
@@ -40,4 +44,34 @@ async def create_new_room(
     """
     return await room_service.create_room(
         schema=schema, request=request, session=session
+    )
+
+
+@rooms_router.get(
+    "",
+    status_code=status.HTTP_200_OK,
+    responses=responses,
+    response_model=RetrieveResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def retrieve_rooms(
+    request: Request,
+    session: typing.Annotated[AsyncSession, Depends(get_async_session)],
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=20, ge=1, le=50),
+) -> typing.Optional[RetrieveResponseDto]:
+    """
+    Retrieves all rooms.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await room_service.retrieve_rooms(
+        page=page, limit=limit, request=request, session=session
     )

--- a/app/tests/v1/room/test_e2e_create_room.py
+++ b/app/tests/v1/room/test_e2e_create_room.py
@@ -20,7 +20,7 @@ class TestCreateRoom:
         self, test_setup: None, client: AsyncClient
     ):
         """
-        Tests user can delete message successfully
+        Tests user can create room successfully
         """
         login_payload = {
             "password": register_input.get("password"),

--- a/app/tests/v1/room/test_e2e_fetch_rooms.py
+++ b/app/tests/v1/room/test_e2e_fetch_rooms.py
@@ -1,0 +1,90 @@
+"""
+Test Fetch Room module
+"""
+
+from unittest.mock import patch
+import pytest
+from httpx import AsyncClient
+
+
+from app.tests.v1.direct_message import register_input
+
+
+class TestFetchRoom:
+    """
+    Test Fetch Room route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_fetch_rooms_successfully(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests user can fetch rooms successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00osqwosdd0asw-pll0-0000-0000-00asq001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                response = await client.post(
+                    url="/api/v1/rooms",
+                    json={
+                        "name": "My room again",
+                        "room_icon": "https://room.com",
+                        "is_private": True,
+                        "messages_delete_able": False,
+                        "is_deactivated": False,
+                        "allow_admin_messages_only": False,
+                    },
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert response.status_code == 201
+
+                # fetch rooms
+                response = await client.get(
+                    url="/api/v1/rooms",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                assert data["message"] == "Rooms retrieved successfully."
+                assert len(data["data"]) > 0


### PR DESCRIPTION

**Description:**

This PR adds support for retrieving a paginated list of chat rooms belonging to the authenticated user via the `GET /api/v1/rooms` endpoint.

### **Endpoint Details:**

**URL:**
`GET /api/v1/rooms`

**Query Parameters:**

* `page` (integer, optional) – Defaults to `1`
* `limit` (integer, optional) – Defaults to `10`

**Headers:**

* `Authorization: Bearer <JWT>` (required)
* `Accept: application/json`

### **Successful Response:**

**Status Code:** `201 Created`

```json
{
  "message": "Room retrieved successfully.",
  "status_code": 201,
  "page": 1,
  "limit": 1,
  "total_pages": 1,
  "total_rooms": 1,
  "data": [
    {
      "id": "f8bac6cd-30da-4422-aacd-34a4ac1fc79a",
      "owner_id": "d3327853-0616-4412-bd65-1749e026d3fa",
      "name": "My Room",
      "room_icon": "https://roomicon.com/image.png",
      "messages_delete_able": true,
      "is_deactivated": false,
      "allow_admin_messages_only": false,
      "is_private": false
    }
  ]
}
```

### **Error Responses:**

* **401 Unauthorized:**

```json
{
  "status_code": 401,
  "message": "Unauthorized",
  "data": {}
}
```

### **Changes Introduced:**

* Implemented `GET /api/v1/rooms` route handler
* Added query parameter handling for pagination (`page`, `limit`)
* Returns metadata such as total pages, room count, etc.
* Validates and enforces authentication via JWT
* Access restricted to authenticated users only
* Results scoped to the requesting user to prevent unauthorized data access

### **Testing Notes:**

* Ensure request contains a valid `Authorization` header
* Confirm pagination works as expected by adjusting `page` and `limit`
* Verify only rooms where the authenticated user is a member are returned



