### PR TITLE
feat: Add endpoint to fetch members of a room

### DIFF
--- a/app/dto/v1/room_member_dto.py
+++ b/app/dto/v1/room_member_dto.py
@@ -1,0 +1,39 @@
+"""
+Room Member DTOs
+"""
+
+from typing import Optional, List
+from pydantic import (
+    BaseModel,
+    Field,
+    ConfigDict,
+)
+
+
+class RoomMemberBaseDto(BaseModel):
+    """
+    RoomMemberBaseDto
+    """
+
+    first_name: Optional[str] = Field(default=None, examples=["Johnson"])
+    last_name: Optional[str] = Field(default=None, examples=["Dennis"])
+    member_id: str = Field(
+        default=None, examples=["222222222222-2222-2222-2222-22222222"]
+    )
+    profile_photo: Optional[str] = Field(default=None, examples=["https://image.com"])
+    is_admin: bool = Field(examples=[False])
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RoomMebersResponseDto(BaseModel):
+    """
+    RoomMebersResponseDto
+    """
+
+    status_code: int = Field(default=200, examples=[200])
+    message: str = Field(
+        default="Room Members fetched succesfully",
+        examples=["Room Members fetched succesfully"],
+    )
+    data: List[Optional[RoomMemberBaseDto]]

--- a/app/repository/v1/room_member_repository.py
+++ b/app/repository/v1/room_member_repository.py
@@ -8,6 +8,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.room_member import RoomMember
+from app.models.room import Room
+from app.models.user import User
 
 
 class RoomMemberRepository:
@@ -31,12 +33,45 @@ class RoomMemberRepository:
             member_id (str): The id of the room member to fetch
             session ( AsyncSession): The async database session object.
             room_id (str): The id of room.
+        Returns:
+            RoomMember or None
         """
         query = sa.select(self.model).where(
             self.model.member_id == member_id, self.model.room_id == room_id
         )
 
         return (await session.execute(query)).scalar_one_or_none()
+
+    async def fetch_all(
+        self, session: AsyncSession, room_id: str
+    ) -> typing.Sequence[typing.Optional[typing.Any]]:
+        """
+        Retrieves all room members.
+
+        Args:
+            session (AsyncSession): The database async session object.
+            room_id (str): The id of the room to fetch.
+        Returns:
+            Sequence of Object or None
+        """
+        query = (
+            sa.select(
+                User.first_name,
+                User.last_name,
+                User.id.label("member_id"),
+                User.profile_photo,
+                RoomMember.is_admin,
+            )
+            .select_from(Room)
+            .join(
+                RoomMember,
+                Room.id == RoomMember.room_id,
+            )
+            .join(User, RoomMember.member_id == User.id)
+            .where(Room.id == room_id, RoomMember.left_room.is_(False))
+        )
+
+        return (await session.execute(query)).mappings().all()
 
 
 room_member_repository = RoomMemberRepository()

--- a/app/route/v1/__init__.py
+++ b/app/route/v1/__init__.py
@@ -9,6 +9,7 @@ from app.route.v1.direct_conversation_route import direct_conversation_router
 from app.route.v1.direct_message_route import direct_message_router
 from app.route.v1.media_upload_route import media_upload_router
 from app.route.v1.room_route import rooms_router
+from app.route.v1.room_member_route import room_members_router
 
 api_version_one = APIRouter(prefix="/api/v1")
 
@@ -16,4 +17,5 @@ api_version_one.include_router(auth_router)
 api_version_one.include_router(direct_conversation_router)
 api_version_one.include_router(direct_message_router)
 api_version_one.include_router(rooms_router)
+api_version_one.include_router(room_members_router)
 api_version_one.include_router(media_upload_router)

--- a/app/route/v1/room_member_route.py
+++ b/app/route/v1/room_member_route.py
@@ -1,0 +1,45 @@
+"""
+Room Member Route Module
+"""
+
+import typing
+from fastapi import APIRouter, status, Request, Depends
+
+from app.utils.responses import responses
+from app.service.v1.room_member_service import room_member_service, AsyncSession
+from app.dto.v1.room_member_dto import (
+    RoomMebersResponseDto,
+)
+from app.core.security import validate_logout_status
+from app.database.session import get_async_session
+
+room_members_router = APIRouter(prefix="/room-members", tags=["ROOM MEMBERS"])
+
+
+@room_members_router.get(
+    "/{room_id}",
+    status_code=status.HTTP_200_OK,
+    responses=responses,
+    response_model=RoomMebersResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def create_new_room(
+    request: Request,
+    room_id: str,
+    session: typing.Annotated[AsyncSession, Depends(get_async_session)],
+) -> typing.Optional[RoomMebersResponseDto]:
+    """
+    Retrieves all room members.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await room_member_service.retrieve_room_members(
+        room_id=room_id, request=request, session=session
+    )

--- a/app/route/v1/room_member_route.py
+++ b/app/route/v1/room_member_route.py
@@ -23,7 +23,7 @@ room_members_router = APIRouter(prefix="/room-members", tags=["ROOM MEMBERS"])
     response_model=RoomMebersResponseDto,
     dependencies=[Depends(validate_logout_status)],
 )
-async def create_new_room(
+async def retrieve_room_members(
     request: Request,
     room_id: str,
     session: typing.Annotated[AsyncSession, Depends(get_async_session)],

--- a/app/service/v1/room_member_service.py
+++ b/app/service/v1/room_member_service.py
@@ -55,7 +55,6 @@ class RoomMemberService:
         all_members = await room_member_repository.fetch_all(
             session=session, room_id=room_id
         )
-        print(all_members)
 
         return RoomMebersResponseDto(
             data=[

--- a/app/service/v1/room_member_service.py
+++ b/app/service/v1/room_member_service.py
@@ -1,0 +1,69 @@
+"""
+Room member service module
+"""
+
+import typing
+from fastapi import Request, status, HTTPException
+
+from app.repository.v1.room_member_repository import (
+    room_member_repository,
+    AsyncSession,
+)
+from app.dto.v1.room_member_dto import RoomMebersResponseDto, RoomMemberBaseDto
+from app.repository.v1.room_repository import room_repository
+
+
+class RoomMemberService:
+    """
+    Room member service class
+    """
+
+    async def retrieve_room_members(
+        self, request: Request, session: AsyncSession, room_id: str
+    ) -> typing.Union[None, RoomMebersResponseDto]:
+        """
+        Retrieves all room members
+
+        Args:
+            request (Request): The request object.
+            session (AsyncSession): The database async session object.
+            room_id (str): The room to fetch its members
+        Returns:
+            RoomMebersResponseDto(pydantic): Response payload
+        """
+        claims: dict = request.state.claims
+        current_user_id = claims.get("user_id", "")
+
+        room_exists = await room_repository.fetch(room_id=room_id, session=session)
+        if not room_exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Room not found"
+            )
+        is_user_a_member = await room_member_repository.fetch(
+            member_id=current_user_id, session=session, room_id=room_id
+        )
+        if not is_user_a_member:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="User not a member"
+            )
+        if is_user_a_member.left_room:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User already left the room",
+            )
+
+        all_members = await room_member_repository.fetch_all(
+            session=session, room_id=room_id
+        )
+        print(all_members)
+
+        return RoomMebersResponseDto(
+            data=[
+                RoomMemberBaseDto.model_validate(member, from_attributes=True)
+                for member in all_members
+                if member
+            ]
+        )
+
+
+room_member_service = RoomMemberService()

--- a/app/tests/v1/room_member/test_e2e_fetch_members.py
+++ b/app/tests/v1/room_member/test_e2e_fetch_members.py
@@ -1,0 +1,292 @@
+"""
+Test Fetch Room-members module
+"""
+
+from unittest.mock import patch
+import pytest
+from httpx import AsyncClient
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tests.v1.direct_message import register_input, register_input_2
+from app.models.room_member import RoomMember
+from app.models.room import Room
+
+
+class TestFetchRoomMember:
+    """
+    Test Fetch Room-Members route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_fetch_room_members_successfully(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests user can fetch room members successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00osqwosdd0asw-pll0-00s0-3432-00asq001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                room_response = await client.post(
+                    url="/api/v1/rooms",
+                    json={
+                        "name": "My room again",
+                        "room_icon": "https://room.com",
+                        "is_private": True,
+                        "messages_delete_able": False,
+                        "is_deactivated": False,
+                        "allow_admin_messages_only": False,
+                    },
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert room_response.status_code == 201
+                room_data = room_response.json()
+                room_id = room_data["data"]["id"]
+
+                # fetch room members
+                fetch_response = await client.get(
+                    url=f"/api/v1/room-members/{room_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert fetch_response.status_code == 200
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "Room Members fetched succesfully"
+                assert len(data["data"]) > 0
+                room_members = []
+                for member in data["data"]:
+                    room_members.append(member["member_id"])
+                assert user_id in room_members
+
+    @pytest.mark.asyncio
+    async def test_b_when_user_not_part_of_room_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user not part of room returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "090909090909-pll0-00s0-3432-00asq001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                second_user_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(owner_id=second_user_id, name="Second room")
+                new_member = RoomMember(
+                    room=new_room, member_id=second_user_id, is_admin=True
+                )
+                test_get_session.add_all([new_room, new_member])
+                await test_get_session.commit()
+
+                # fetch room members
+                fetch_response = await client.get(
+                    url=f"/api/v1/room-members/{new_room.id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert fetch_response.status_code == 403
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "User not a member"
+
+    @pytest.mark.asyncio
+    async def test_c_when_user_already_left_room_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user already left room returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "090909090999-pll0-00s0-3432-00asq001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(owner_id=user_id, name="Second room")
+                new_member = RoomMember(
+                    room=new_room, member_id=user_id, is_admin=True, left_room=True
+                )
+                test_get_session.add_all([new_room, new_member])
+                await test_get_session.commit()
+
+                # fetch room members
+                fetch_response = await client.get(
+                    url=f"/api/v1/room-members/{new_room.id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert fetch_response.status_code == 403
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "User already left the room"
+
+    @pytest.mark.asyncio
+    async def test_d_when_invalid_room_id_returns_404(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when invalid room id returns 404
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "090999090999-pll0-00s0-3432-00asq001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+
+                # fetch room members
+                fetch_response = await client.get(
+                    url=f"/api/v1/room-members/123-34234-34-44-435345",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert fetch_response.status_code == 404
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "Room not found"


### PR DESCRIPTION


### **Description:**

This PR introduces a new API endpoint that allows an authenticated user to retrieve the list of members in a specific chat room.

### **Endpoint:**

`GET /api/v1/room_members/{room_id}`

---

### **Response Examples:**

**✅ 200 OK – Room members fetched successfully**

```json
{
  "status_code": 200,
  "message": "Room Members fetched succesfully",
  "data": [
    {
      "first_name": null,
      "last_name": null,
      "member_id": "d3327853-0616-4412-bd65-1749e026d3fa",
      "profile_photo": null,
      "is_admin": true
    }
  ]
}
```

**🔒 401 Unauthorized – Missing or invalid token**

```json
{
  "status_code": 401,
  "message": "Unauthorized",
  "data": {}
}
```

**🚫 403 Forbidden – User not part of the room or already left**

```json
{
  "status_code": 403,
  "message": "Forbidden",
  "data": {}
}
```

**❌ 404 Not Found – Invalid room ID**

```json
{
  "status_code": 404,
  "message": "Room not found",
  "data": {}
}
```

---

### **Test Coverage:**

All relevant end-to-end tests for this feature have passed:

* ✅ `test_a_user_can_fetch_room_members_successfully`
* ✅ `test_b_when_user_not_part_of_room_returns_403`
* ✅ `test_c_when_user_already_left_room_returns_403`
* ✅ `test_d_when_invalid_room_id_returns_404`

Test file:
`app/tests/v1/room_member/test_e2e_fetch_members.py`

---

### **Notes:**

* Requires Bearer Token Authorization.
* Assumes the user is a current member of the room.
* Handles authorization, membership status, and room validity checks.
