### PR TITLE
feat: Add Endpoint to Add Members to a Room (`POST /api/v1/room-members/:room_id`)

### DIFF
--- a/app/dto/v1/room_member_dto.py
+++ b/app/dto/v1/room_member_dto.py
@@ -2,11 +2,12 @@
 Room Member DTOs
 """
 
-from typing import Optional, List
+from typing import Optional, List, Annotated
 from pydantic import (
     BaseModel,
     Field,
     ConfigDict,
+    StringConstraints,
 )
 
 
@@ -37,3 +38,28 @@ class RoomMebersResponseDto(BaseModel):
         examples=["Room Members fetched succesfully"],
     )
     data: List[Optional[RoomMemberBaseDto]]
+
+
+# +++++++++++++++++++++++++ Add Room Member ++++++++++++++++++++++++++++
+class AddRoomMemberRequestDto(BaseModel):
+    """
+    Add room member
+    """
+
+    member_id: Annotated[
+        str, StringConstraints(min_length=20, max_length=40, strip_whitespace=True)
+    ] = Field(examples=["121212121212-1212-2121-2121-21212121"])
+    is_admin: bool = Field(examples=[True])
+
+
+class AddRoomMemberResponseDto(BaseModel):
+    """
+    AddRoomMemberResponseDto
+    """
+
+    status_code: int = Field(default=201, examples=[201])
+    message: str = Field(
+        default="Room Member added succesfully",
+        examples=["Room Member added succesfully"],
+    )
+    data: dict = Field(default={}, examples=[{}])

--- a/app/repository/v1/room_member_repository.py
+++ b/app/repository/v1/room_member_repository.py
@@ -23,6 +23,26 @@ class RoomMemberRepository:
         """
         self.model = RoomMember
 
+    async def create(
+        self, room_id: str, member_id: str, is_admin: bool, session: AsyncSession
+    ) -> RoomMember:
+        """
+        Adds a new member to a room.
+
+        Args:
+            member_id (str): The id of the room member to fetch.
+            session ( AsyncSession): The async database session object.
+            room_id (str): The id of room.
+            is_admin (bool): The admin status of the new member to add.
+        Returns:
+            RoomMember
+        """
+        new_member = RoomMember(member_id=member_id, room_id=room_id, is_admin=is_admin)
+        session.add(new_member)
+
+        await session.commit()
+        return new_member
+
     async def fetch(
         self, member_id: str, session: AsyncSession, room_id: str
     ) -> typing.Optional[RoomMember]:

--- a/app/repository/v1/room_member_repository.py
+++ b/app/repository/v1/room_member_repository.py
@@ -93,5 +93,27 @@ class RoomMemberRepository:
 
         return (await session.execute(query)).mappings().all()
 
+    async def update(
+        self,
+        room_id: str,
+        session: AsyncSession,
+        member_id: str,
+        is_admin: typing.Union[None, bool],
+        left_room: typing.Union[None, bool],
+    ):
+        """
+        Updates room member status
+        """
+        query = sa.update(RoomMember).where(
+            RoomMember.room_id == room_id, RoomMember.member_id == member_id
+        )
+        if is_admin is not None:
+            query = query.values(is_admin=is_admin)
+        if left_room is not None:
+            query = query.values(left_room=left_room)
+        
+        await session.execute(query)
+        await session.commit()
+
 
 room_member_repository = RoomMemberRepository()

--- a/app/route/v1/room_member_route.py
+++ b/app/route/v1/room_member_route.py
@@ -9,6 +9,8 @@ from app.utils.responses import responses
 from app.service.v1.room_member_service import room_member_service, AsyncSession
 from app.dto.v1.room_member_dto import (
     RoomMebersResponseDto,
+    AddRoomMemberRequestDto,
+    AddRoomMemberResponseDto,
 )
 from app.core.security import validate_logout_status
 from app.database.session import get_async_session
@@ -42,4 +44,34 @@ async def retrieve_room_members(
     """
     return await room_member_service.retrieve_room_members(
         room_id=room_id, request=request, session=session
+    )
+
+
+@room_members_router.post(
+    "/{room_id}",
+    status_code=status.HTTP_201_CREATED,
+    responses=responses,
+    response_model=AddRoomMemberResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def add_room_member(
+    request: Request,
+    room_id: str,
+    schema: AddRoomMemberRequestDto,
+    session: typing.Annotated[AsyncSession, Depends(get_async_session)],
+) -> typing.Optional[AddRoomMemberResponseDto]:
+    """
+    Adds a new room member.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await room_member_service.add_room_member(
+        room_id=room_id, request=request, session=session, schema=schema
     )

--- a/app/service/v1/room_member_service.py
+++ b/app/service/v1/room_member_service.py
@@ -120,6 +120,23 @@ class RoomMemberService:
                 detail="User already left the room",
             )
 
+        is_user_a_member = await room_member_repository.fetch(
+            member_id=schema.member_id, session=session, room_id=room_id
+        )
+        if is_user_a_member and is_user_a_member.left_room:
+            await room_member_repository.update(
+                session=session,
+                room_id=room_id,
+                member_id=schema.member_id,
+                left_room=False,
+                is_admin=schema.is_admin,
+            )
+            return AddRoomMemberResponseDto()
+        if is_user_a_member and not is_user_a_member.left_room:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="User already a member"
+            )
+
         try:
             await room_member_repository.create(
                 session=session,

--- a/app/tests/v1/room_member/test_e2e_add_room_member.py
+++ b/app/tests/v1/room_member/test_e2e_add_room_member.py
@@ -1,0 +1,401 @@
+"""
+Test Add Room-members module
+"""
+
+from unittest.mock import patch
+import pytest
+from httpx import AsyncClient
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tests.v1.direct_message import register_input, register_input_2
+from app.models.room_member import RoomMember
+from app.models.room import Room
+
+
+class TestAddRoomMember:
+    """
+    Test Add Room-Member route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_add_room_member_successfully(
+        self, test_setup: None, client: AsyncClient
+    ):
+        """
+        Tests user can add new room member successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00osq00sdd0asw-pll0-00s0-3432-00asq001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+
+                second_user_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                room_response = await client.post(
+                    url="/api/v1/rooms",
+                    json={
+                        "name": "My room again",
+                        "room_icon": "https://room.com",
+                        "is_private": True,
+                        "messages_delete_able": False,
+                        "is_deactivated": False,
+                        "allow_admin_messages_only": False,
+                    },
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert room_response.status_code == 201
+                room_data = room_response.json()
+                room_id = room_data["data"]["id"]
+
+                # add room member
+                fetch_response = await client.post(
+                    url=f"/api/v1/room-members/{room_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    json={"is_admin": True, "member_id": second_user_id},
+                )
+
+                assert fetch_response.status_code == 201
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "Room Member added succesfully"
+
+                # fetch room members
+                fetch_response = await client.get(
+                    url=f"/api/v1/room-members/{room_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+                assert fetch_response.status_code == 200
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "Room Members fetched succesfully"
+                assert len(data["data"]) > 0
+                room_members = []
+                for member in data["data"]:
+                    room_members.append(member["member_id"])
+                assert user_id in room_members
+                assert second_user_id in room_members
+
+    @pytest.mark.asyncio
+    async def test_b_when_user_not_a_member_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user not a member returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00osq00sdd0asw-pll0-00s0-3432-0000q001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+
+                second_user_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(owner_id=second_user_id, name="Great Room")
+                new_member = RoomMember(
+                    member_id=second_user_id, is_admin=True, room=new_room
+                )
+                test_get_session.add_all([new_room, new_member])
+                await test_get_session.commit()
+
+                # add room member
+                fetch_response = await client.post(
+                    url=f"/api/v1/room-members/{new_room.id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    json={"is_admin": True, "member_id": second_user_id},
+                )
+
+                assert fetch_response.status_code == 403
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "User not a member"
+
+    @pytest.mark.asyncio
+    async def test_b_when_user_not_admin_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user not admin member returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "00osq00sdd0asw-pll0-00s0-3432-0011q001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+
+                second_user_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(owner_id=second_user_id, name="Great Room")
+                new_member = RoomMember(
+                    member_id=second_user_id, is_admin=True, room=new_room
+                )
+                new_member2 = RoomMember(
+                    member_id=user_id, is_admin=False, room=new_room
+                )
+                test_get_session.add_all([new_room, new_member, new_member2])
+                await test_get_session.commit()
+
+                # add room member
+                fetch_response = await client.post(
+                    url=f"/api/v1/room-members/{new_room.id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    json={"is_admin": True, "member_id": second_user_id},
+                )
+
+                assert fetch_response.status_code == 403
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "User not an admin"
+
+    @pytest.mark.asyncio
+    async def test_b_when_user_left_room_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user already left room returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "54osq00sdd0asw-pll0-00s0-3432-0011q001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+
+                second_user_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                access_token = data["data"]["access_token"]["token"]
+                user_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(owner_id=second_user_id, name="Great Room")
+
+                new_member2 = RoomMember(
+                    member_id=user_id, is_admin=True, room=new_room, left_room=True
+                )
+                test_get_session.add_all([new_room, new_member2])
+                await test_get_session.commit()
+
+                # add room member
+                fetch_response = await client.post(
+                    url=f"/api/v1/room-members/{new_room.id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    json={"is_admin": True, "member_id": second_user_id},
+                )
+
+                assert fetch_response.status_code == 403
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "User already left the room"
+
+    @pytest.mark.asyncio
+    async def test_b_when_user_not_authenticated_returns_401(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user not authenticated returns 401
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": "54osq00sdd0asw-pll0-00s0-3432-sa11q001",
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                # add room member
+                fetch_response = await client.post(
+                    url="/api/v1/room-members/3432-4234-5435-3453",
+                    json={"is_admin": True, "member_id": "3-42342-4535-35454654"},
+                )
+
+                assert fetch_response.status_code == 401
+
+                data: dict = fetch_response.json()
+
+                assert data["message"] == "Missing Authorization header"


### PR DESCRIPTION


**Summary:**

This PR introduces the functionality to add a user to an existing room by its ID. The authenticated user must be an active **admin member** of the room to perform this action. The endpoint allows optional promotion of the new member to admin status.

---

### **Endpoint:**

`POST /api/v1/room-members/:room_id`

**Example URL:**
`POST /api/v1/room-members/f8bac6cd-30da-4422-aacd-34a4ac1fc79a`

---

### **Headers:**

* `Authorization: Bearer <access_token>`
* `Content-Type: application/json`
* `Accept: application/json`

---

### **Request Body:**

```json
{
  "member_id": "b62d3b3c-9a0b-4540-b7f4-72947d4d97f0",
  "is_admin": true
}
```

---

### ✅ **Successful Response – 201 Created:**

```json
{
  "status_code": 201,
  "message": "Room Member added succesfully",
  "data": {}
}
```

---

### 🔒 **Error – 401 Unauthorized:**

```json
{
  "status_code": 401,
  "message": "Unauthorized",
  "data": {}
}
```

---

### 🔐 **Other Possible Errors (Handled in Code):**

* 403 Forbidden if:

  * Requesting user is **not a room member**
  * Requesting user is **not an admin**
  * Requesting user **left the room previously**

---

### ✅ **Test Coverage (100%)**

Test cases have been implemented and passed successfully:

```bash
app/tests/v1/room_member/test_e2e_add_room_member.py
```

| Test Case Description                                 | Result |
| ----------------------------------------------------- | ------ |
| test\_a\_user\_can\_add\_room\_member\_successfully   | ✅      |
| test\_b\_when\_user\_not\_a\_member\_returns\_403     | ✅      |
| test\_b\_when\_user\_not\_admin\_returns\_403         | ✅      |
| test\_b\_when\_user\_left\_room\_returns\_403         | ✅      |
| test\_b\_when\_user\_not\_authenticated\_returns\_401 | ✅      |

---

**Implementation Notes:**

* Validates the requesting user’s admin role and room membership.
* Supports promoting added members to admin during creation.
* Prevents re-adding members who were removed or left (via 403).

---

**Next Steps / Suggestions:**

* Add support for bulk adding members.
* Emit room activity events (e.g., notifications, audit logs).
* Include timestamps and user details in response for better UI feedback.

