### PR TITLE
feat: Handle Room Invitation Actions (Accept / Decline / Cancel) — `PATCH /api/v1/room-invitations`

### DIFF
--- a/app/dto/v1/room_inivitation_dto.py
+++ b/app/dto/v1/room_inivitation_dto.py
@@ -4,6 +4,7 @@ Room invitation dto module
 
 from typing import Annotated
 from datetime import datetime
+from enum import Enum
 
 from pydantic import BaseModel, Field, ConfigDict, StringConstraints
 
@@ -52,3 +53,48 @@ class RoomInvitationResponseDto(BaseModel):
 
 
 # +++++++++++++++++++++++++++++++++++++++ ROom invitation accept/reject +++++++++++++++++++++++++++===
+class InvitationStatusEnum(str, Enum):
+    """
+    Invitation status enum
+    """
+
+    DECLINE = "decline"
+    CANCEL = "cancel"
+    ACCEPT = "accept"
+
+
+class RoomInvitationUpdateRequestDto(BaseModel):
+    """
+    RoomInvitationUpdateRequestDto
+    """
+
+    invitation_id: Annotated[
+        str, StringConstraints(min_length=20, max_length=40, strip_whitespace=True)
+    ] = Field(examples=["312423-4-3544354-5-41342165"])
+    room_id: Annotated[
+        str, StringConstraints(min_length=20, max_length=40, strip_whitespace=True)
+    ] = Field(examples=["312423-4-3544354-5-41342165"])
+    action: InvitationStatusEnum = Field(examples=["accept"])
+
+
+class RoomInvitationUpdateResponseDto(BaseModel):
+    """
+    RoomInvitationUpdateResponseDto
+    """
+
+    status_code: int = Field(default=200, examples=[200])
+    message: str = Field(
+        default="Invitation request cancelled successfully.",
+        examples=["Invitation request cancelled successfully."],
+    )
+    data: dict = Field(
+        examples=[
+            {
+                "invitation_status": "cancelled",
+                "invitation_id": "312423-4-3544354-5-41342165",
+            }
+        ]
+    )
+
+
+# +++++++++++++++++++++++++++++++++++++++ Fetch ROom invitations +++++++++++++++++++++++++++===

--- a/app/repository/v1/room_invitation_repository.py
+++ b/app/repository/v1/room_invitation_repository.py
@@ -19,7 +19,15 @@ class RoomInvitationRepository:
         self, session: AsyncSession, room_id: str, inviter_id: str, invitee_id: str
     ) -> RoomInvitation:
         """
-        Creates a room invitation
+        Creates a room invitation.
+
+        Args:
+            session (AsyncSession): The database async session object.
+            room_id (str): The id of the Room for invitation.
+            inviter_id (str): The id of the user inviting another user.
+            invitee_id (str): The id of the user been invited by another user.
+        Returns:
+            RoomInvitation (object): The room-invitation instance.
         """
         expiration = datetime.now(timezone.utc) + timedelta(days=7)
         new_invitation = RoomInvitation(
@@ -36,21 +44,36 @@ class RoomInvitationRepository:
     async def fetch(
         self,
         session: AsyncSession,
-        room_id: str,
+        room_id: typing.Union[None, str],
         inviter_id: typing.Union[None, str],
         invitee_id: typing.Union[None, str],
         invitation_status: typing.Union[None, str],
+        invitation_id: typing.Union[None, str],
     ) -> typing.Union[None, RoomInvitation]:
         """
-        Fetches a room invitation
+        Fetches a room invitation.
+
+        Args:
+            session (AsyncSession): The database async session object.
+            room_id (str): The Optional id of the Room for invitation.
+            inviter_id (str): The Optional id of the user inviting another user.
+            invitee_id (str): The Optional id of the user been invited by another user.
+            invitation_status (str): The Optional status of the invitation.
+            invitation_id (str): The Optional id of the invitation.
+        Returns:
+            int: The number of affected rows
         """
-        query = sa.select(RoomInvitation).where(RoomInvitation.room_id == room_id)
+        query = sa.select(RoomInvitation)
+        if room_id:
+            query = query.where(RoomInvitation.room_id == room_id)
         if inviter_id:
             query = query.where(RoomInvitation.inviter_id == inviter_id)
         if invitee_id:
             query = query.where(RoomInvitation.invitee_id == invitee_id)
         if invitation_status:
             query = query.where(RoomInvitation.invitation_status == invitation_status)
+        if invitation_id:
+            query = query.where(RoomInvitation.id == invitation_id)
 
         return (await session.execute(query)).scalar_one_or_none()
 
@@ -58,13 +81,23 @@ class RoomInvitationRepository:
         self, session: AsyncSession, invitation_id: str, status: str
     ) -> int:
         """
-        Updates room invitation
+        Updates room invitation.
+
+        Args:
+            session (AsyncSession): The database async session object.
+            invitation_id (str): The id of the invitation.
+            status (str): The status of the invitation.
+        Returns:
+            int: The number of affected rows
         """
+        expiration = datetime.now(timezone.utc) + timedelta(days=7)
         query = (
             sa.update(RoomInvitation)
             .where(RoomInvitation.id == invitation_id)
             .values(invitation_status=status)
         )
+        if status == "pending":
+            query = query.values(expiration=expiration, invitation_status=status)
 
         result = await session.execute(query)
         await session.commit()

--- a/app/route/v1/room_invitation_route.py
+++ b/app/route/v1/room_invitation_route.py
@@ -10,6 +10,8 @@ from app.service.v1.room_invitation_service import room_invitation_service, Asyn
 from app.dto.v1.room_inivitation_dto import (
     RoomInvitationRequestDto,
     RoomInvitationResponseDto,
+    RoomInvitationUpdateResponseDto,
+    RoomInvitationUpdateRequestDto,
 )
 from app.core.security import validate_logout_status
 from app.database.session import get_async_session
@@ -43,4 +45,33 @@ async def invite_users_to_room(
     """
     return await room_invitation_service.create_room_invitation(
         schema=schema, request=request, session=session
+    )
+
+
+@room_invitation_router.patch(
+    "",
+    status_code=status.HTTP_200_OK,
+    responses=responses,
+    response_model=RoomInvitationUpdateResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def update_room_invitation_request(
+    request: Request,
+    schema: RoomInvitationUpdateRequestDto,
+    session: typing.Annotated[AsyncSession, Depends(get_async_session)],
+) -> typing.Optional[RoomInvitationUpdateResponseDto]:
+    """
+    Declines, accepts, ignores and cancels room invitation.
+
+    Return:
+        Success message upon success
+    Raises:
+        422
+        500
+        409
+        401
+        404
+    """
+    return await room_invitation_service.update_room_invitation_request(
+        schema=schema, session=session, request=request
     )

--- a/app/service/v1/room_invitation_service.py
+++ b/app/service/v1/room_invitation_service.py
@@ -14,6 +14,8 @@ from app.dto.v1.room_inivitation_dto import (
     RoomInvitationBaseDto,
     RoomInvitationRequestDto,
     RoomInvitationResponseDto,
+    RoomInvitationUpdateRequestDto,
+    RoomInvitationUpdateResponseDto,
 )
 
 
@@ -26,7 +28,14 @@ class RoomInvitationService:
         self, request: Request, session: AsyncSession, schema: RoomInvitationRequestDto
     ) -> typing.Optional[RoomInvitationResponseDto]:
         """
-        Creates a new room invitation
+        Creates a new room invitation.
+
+        Args:
+            request (Request): The request object.
+            session (AsyncSession): The database async session object.
+            schema (RoomInvitationRequestDto): The request payload.
+        Returns:
+            RoomInvitationResponseDto (pydantic): The response payload
         """
         claims: dict = request.state.claims
         current_user_id = claims.get("user_id", "")
@@ -84,6 +93,7 @@ class RoomInvitationService:
             invitee_id=schema.invitee_id,
             inviter_id=None,
             invitation_status=None,
+            invitation_id=None,
         )
 
         if (
@@ -127,6 +137,137 @@ class RoomInvitationService:
             new_invitation, from_attributes=True
         )
         return RoomInvitationResponseDto(data=invitation_base)
+
+    async def update_room_invitation_request(
+        self,
+        request: Request,
+        session: AsyncSession,
+        schema: RoomInvitationUpdateRequestDto,
+    ) -> typing.Optional[RoomInvitationUpdateResponseDto]:
+        """
+        Updates room invitation request.
+
+        Args:
+            request (Request): The request object.
+            session (AsyncSession): The database async session object.
+            schema (RoomInvitationUpdateRequestDto): The request payload.
+        Returns:
+            RoomInvitationUpdateResponseDto (pydantic): The response payload
+        """
+        message = "Invitation request updated successfully."
+        claims: dict = request.state.claims
+        current_user_id = claims.get("user_id", "")
+
+        room_exists = await room_repository.fetch(
+            session=session, room_id=schema.room_id
+        )
+        if not room_exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Room not found"
+            )
+        if room_exists.is_deactivated:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Room deactivated. New Members no longer allowed",
+            )
+
+        invitation_exists = await room_invitation_repository.fetch(
+            session=session,
+            invitation_id=schema.invitation_id,
+            invitation_status=None,
+            invitee_id=None,
+            inviter_id=None,
+            room_id=None,
+        )
+        if not invitation_exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found"
+            )
+        if current_user_id not in [
+            invitation_exists.inviter_id,
+            invitation_exists.invitee_id,
+        ]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User has not enough access to this invitation",
+            )
+        is_room_member = await room_member_repository.fetch(
+            session=session, member_id=current_user_id, room_id=schema.room_id
+        )
+
+        if schema.action.value == "cancel":
+            # admin or inviter is cancelling invitation
+            if is_room_member and is_room_member.left_room:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="User already left the Room.Cannot cancel invitation",
+                )
+            if is_room_member and not is_room_member.is_admin:
+                # check if room-invitation allowed for non-admins
+                if not room_exists.allow_non_admin_invitations:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="Room only allows privileges to Admins",
+                    )
+            # handle case where room-invitation has already been accepted
+            if invitation_exists.invitation_status != "pending":
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Cannot cancel request, invitation is already {invitation_exists.invitation_status}",
+                )
+            await room_invitation_repository.update(
+                session=session, status="cancelled", invitation_id=schema.invitation_id
+            )
+            message = "Invitation request cancelled successfully."
+        elif schema.action.value == "decline":
+            # invitee is declining the invitation
+            if invitation_exists.invitee_id != current_user_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Cannot decline invitation for invitee",
+                )
+            if invitation_exists.invitation_status != "pending":
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Cannot decline invitation request, invitation is already {invitation_exists.invitation_status}",
+                )
+            await room_invitation_repository.update(
+                session=session, status="declined", invitation_id=schema.invitation_id
+            )
+            message = "Invitation request declined successfully."
+
+        elif schema.action.value == "accept":
+            # invitee is accepting the invitation
+            if invitation_exists.invitee_id != current_user_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Cannot accept invitation for invitee",
+                )
+            if invitation_exists.invitation_status != "pending":
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Cannot accept invitation request, invitation is already {invitation_exists.invitation_status}",
+                )
+            await room_invitation_repository.update(
+                session=session, status="accepted", invitation_id=schema.invitation_id
+            )
+            _ = await room_member_repository.create(
+                room_id=schema.room_id,
+                session=session,
+                is_admin=False,
+                member_id=invitation_exists.invitee_id,
+            )
+            message = "Invitation request accepted successfully."
+        await session.refresh(
+            instance=invitation_exists, attribute_names=["invitation_status"]
+        )
+        return RoomInvitationUpdateResponseDto(
+            data={
+                "invitation_status": invitation_exists.invitation_status,
+                "invitation_id": schema.invitation_id,
+            },
+            message=message,
+        )
 
 
 room_invitation_service = RoomInvitationService()

--- a/app/tests/v1/room_invitation/test_e2e_update_invitations.py
+++ b/app/tests/v1/room_invitation/test_e2e_update_invitations.py
@@ -1,0 +1,1252 @@
+"""
+Test Update Room invitations module
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+import pytest
+from httpx import AsyncClient
+
+# import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tests.v1.room_invitation import register_input, register_input_2
+from app.models.room_member import RoomMember
+from app.models.room import Room
+from app.models.room_invitation import RoomInvitation
+
+
+class TestUpdateRoomInvitation:
+    """
+    Test  Update Room invitations route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_accept_invitation_successfully(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests user can accept invitation successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(name="My Dear room", owner_id=user_two_id)
+                member = RoomMember(member_id=user_two_id, room=new_room, is_admin=True)
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_one_id,
+                    inviter_id=user_two_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # accept invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "accept",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 200
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Invitation request accepted successfully."
+                )
+                assert invite_data["data"]["invitation_status"] == "accepted"
+
+    @pytest.mark.asyncio
+    async def test_b_user_can_reject_invitation_successfully(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests user can reject invitation successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(name="My Dear room", owner_id=user_two_id)
+                member = RoomMember(member_id=user_two_id, room=new_room, is_admin=True)
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_one_id,
+                    inviter_id=user_two_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # accept invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "decline",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 200
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Invitation request declined successfully."
+                )
+                assert invite_data["data"]["invitation_status"] == "declined"
+
+    @pytest.mark.asyncio
+    async def test_c_user_can_cancel_invitation_successfully(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests user can cancel invitation successfully
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(name="My Dear room", owner_id=user_one_id)
+                member = RoomMember(member_id=user_one_id, room=new_room, is_admin=True)
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 200
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Invitation request cancelled successfully."
+                )
+                assert invite_data["data"]["invitation_status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_d_when_room_not_found_returns_404(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when room not found returns 404
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": "31234343543546565464674",
+                        "room_id": "121212121212-1212-12121-21212121",
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 404
+
+                invite_data: dict = invite_response.json()
+
+                assert invite_data["message"] == "Room not found"
+
+    @pytest.mark.asyncio
+    async def test_e_when_room_deactivated_returns_400(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when room deactivated returns 400
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room", owner_id=user_one_id, is_deactivated=True
+                )
+                member = RoomMember(member_id=user_one_id, room=new_room, is_admin=True)
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 400
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Room deactivated. New Members no longer allowed"
+                )
+
+    @pytest.mark.asyncio
+    async def test_f_when_invitation_not_found_returns_404(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when invitation not found returns 404
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room", owner_id=user_one_id, is_deactivated=False
+                )
+                member = RoomMember(member_id=user_one_id, room=new_room, is_admin=True)
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": "121212121212-1212-1212-12121212",
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 404
+
+                invite_data: dict = invite_response.json()
+
+                assert invite_data["message"] == "Invitation not found"
+
+    @pytest.mark.asyncio
+    async def test_g_when_current_has_no_access_to_invitation(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when current has no access to invitation returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room", owner_id=user_two_id, is_deactivated=False
+                )
+                member = RoomMember(member_id=user_two_id, room=new_room, is_admin=True)
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_two_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 403
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "User has not enough access to this invitation"
+                )
+
+    @pytest.mark.asyncio
+    async def test_h_when_admin_already_left_room_and_cannot_cancel_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when admin already left room returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(name="My Dear room", owner_id=user_one_id)
+                member = RoomMember(
+                    member_id=user_one_id, room=new_room, is_admin=True, left_room=True
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 403
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "User already left the Room.Cannot cancel invitation"
+                )
+
+    @pytest.mark.asyncio
+    async def test_i_when_only_admin_can_cancel_invitation_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when only admin can cancel invitation returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room",
+                    owner_id=user_one_id,
+                    allow_non_admin_invitations=False,
+                )
+                member = RoomMember(
+                    member_id=user_one_id,
+                    room=new_room,
+                    is_admin=False,
+                    left_room=False,
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 403
+
+                invite_data: dict = invite_response.json()
+
+                assert invite_data["message"] == "Room only allows privileges to Admins"
+
+    @pytest.mark.asyncio
+    async def test_j_when_invitation_is_not_pending_admin_cannot_cancel_invitation_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when invitation is not pending admin cannot cancel invitation returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room",
+                    owner_id=user_one_id,
+                    allow_non_admin_invitations=False,
+                )
+                member = RoomMember(
+                    member_id=user_one_id,
+                    room=new_room,
+                    is_admin=True,
+                    left_room=False,
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                    invitation_status="accepted",
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "cancel",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 409
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Cannot cancel request, invitation is already accepted"
+                )
+
+    @pytest.mark.asyncio
+    async def test_k_when_action_is_decline_and_current_user_is_not_invitee_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when action is decline and current user is not invitee returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room",
+                    owner_id=user_one_id,
+                    allow_non_admin_invitations=False,
+                )
+                member = RoomMember(
+                    member_id=user_one_id,
+                    room=new_room,
+                    is_admin=True,
+                    left_room=False,
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "decline",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 403
+
+                invite_data: dict = invite_response.json()
+
+                assert invite_data["message"] == "Cannot decline invitation for invitee"
+
+    @pytest.mark.asyncio
+    async def test_l_when_action_is_decline_and_invitation_is_not_pending_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when action is decline and invitation is not pending returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room",
+                    owner_id=user_two_id,
+                    allow_non_admin_invitations=False,
+                )
+                member = RoomMember(
+                    member_id=user_two_id,
+                    room=new_room,
+                    is_admin=True,
+                    left_room=False,
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_one_id,
+                    inviter_id=user_two_id,
+                    expiration=expiration,
+                    invitation_status="declined",
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "decline",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 409
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Cannot decline invitation request, invitation is already declined"
+                )
+
+    @pytest.mark.asyncio
+    async def test_m_when_action_is_accept_and_current_user_is_not_invitee_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when action is accept and current user is not invitee returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room",
+                    owner_id=user_one_id,
+                    allow_non_admin_invitations=False,
+                )
+                member = RoomMember(
+                    member_id=user_one_id,
+                    room=new_room,
+                    is_admin=True,
+                    left_room=False,
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_two_id,
+                    inviter_id=user_one_id,
+                    expiration=expiration,
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "accept",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 403
+
+                invite_data: dict = invite_response.json()
+
+                assert invite_data["message"] == "Cannot accept invitation for invitee"
+
+    @pytest.mark.asyncio
+    async def test_n_when_action_is_accept_and_invitation_is_not_pending_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when action is accept and invitation is not pending returns 403
+        """
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": register_input.get("email"),
+            "session_id": str(uuid.uuid4()),
+        }
+
+        with patch(
+            "app.service.v1.authentication_service.AuthenticationService.send_email",
+            return_value=None,
+        ):
+            with patch(
+                "app.service.v1.authentication_service.AuthenticationService.generate_six_digit_code",
+                return_value="123456",
+            ):
+                # register first user
+                response = await client.post(
+                    url="/api/v1/auth/register", json=register_input
+                )
+                assert response.status_code == 201
+                # register second user
+                response2 = await client.post(
+                    url="/api/v1/auth/register", json=register_input_2
+                )
+                assert response2.status_code == 201
+                data2 = response2.json()
+                user_two_id = data2["data"]["id"]
+
+                # verify first user
+                await client.patch(
+                    url="/api/v1/auth/verify-account",
+                    json={"email": register_input.get("email"), "code": "123456"},
+                )
+
+                # login first user
+                response = await client.post(
+                    url="/api/v1/auth/login", json=login_payload
+                )
+
+                assert response.status_code == 200
+
+                data: dict = response.json()
+
+                user_one_access_token = data["data"]["access_token"]["token"]
+                user_one_id = data["data"]["user_data"]["id"]
+
+                # create room
+                new_room = Room(
+                    name="My Dear room",
+                    owner_id=user_two_id,
+                    allow_non_admin_invitations=False,
+                )
+                member = RoomMember(
+                    member_id=user_two_id,
+                    room=new_room,
+                    is_admin=True,
+                    left_room=False,
+                )
+                expiration = datetime.now(timezone.utc) + timedelta(days=7)
+                invitation = RoomInvitation(
+                    room=new_room,
+                    invitee_id=user_one_id,
+                    inviter_id=user_two_id,
+                    expiration=expiration,
+                    invitation_status="accepted",
+                )
+                test_get_session.add_all([new_room, member, invitation])
+                await test_get_session.commit()
+
+                # cancel invitation to room
+                invite_response = await client.patch(
+                    url="/api/v1/room-invitations",
+                    json={
+                        "invitation_id": invitation.id,
+                        "room_id": new_room.id,
+                        "action": "accept",
+                    },
+                    headers={"Authorization": f"Bearer {user_one_access_token}"},
+                )
+
+                assert invite_response.status_code == 409
+
+                invite_data: dict = invite_response.json()
+
+                assert (
+                    invite_data["message"]
+                    == "Cannot accept invitation request, invitation is already accepted"
+                )


### PR DESCRIPTION


### **Summary:**

This PR implements the logic for **updating the status of a room invitation** by performing one of three actions: `accept`, `decline`, or `cancel`. It includes permission checks, room and invitation existence validations, and strict enforcement of invitation state (only `pending` invitations can be acted upon).

---

### **Endpoint:**

`PATCH /api/v1/room-invitations`

---

### **Headers:**

* `Authorization: Bearer <access_token>`
* `Content-Type: application/json`
* `Accept: application/json`

---

### **Request Body Example:**

```json
{
  "invitation_id": "312423-4-3544354-5-41342165",
  "room_id": "312423-4-3544354-5-41342165",
  "action": "accept"
}
```

**Valid `action` values:**

* `"accept"` — for invitees to join the room
* `"decline"` — for invitees to reject the invitation
* `"cancel"` — for admins to cancel invitations they sent

---

### ✅ **Success Response – 200 OK**

```json
{
  "status_code": 200,
  "message": "Invitation request cancelled successfully.",
  "data": {
    "invitation_id": "312423-4-3544354-5-41342165",
    "invitation_status": "cancelled"
  }
}
```

---

### ❌ **Error Responses:**

**401 Unauthorized:**

```json
{
  "status_code": 401,
  "message": "Unauthorized",
  "data": {}
}
```

**404 Room or Invitation Not Found:**

```json
{
  "status_code": 404,
  "message": "Room not found",
  "data": {}
}
```

**403 Forbidden** (various logic cases):

* Non-invitee trying to accept/decline
* Non-admin trying to cancel
* Trying to act on a non-pending invitation
* Admin already left room, etc.

**400 Bad Request:**

* If the room is deactivated or malformed request payload.

---

### 🧪 **Test Coverage:**

Tests are implemented in:
`app/tests/v1/room_invitation/test_e2e_update_invitations.py`

All test cases passed:

| Test Case Description                                   | Status |
| ------------------------------------------------------- | ------ |
| User can accept invitation                              | ✅      |
| User can reject invitation                              | ✅      |
| Admin can cancel invitation                             | ✅      |
| Fails if room not found                                 | ✅      |
| Fails if room is deactivated                            | ✅      |
| Fails if invitation not found                           | ✅      |
| Fails if current user has no access to the invitation   | ✅      |
| Admin left room → cannot cancel                         | ✅      |
| Only admins can cancel                                  | ✅      |
| Admin cannot cancel invitation if status is not pending | ✅      |
| Non-invitee trying to decline invitation                | ✅      |
| Invitee tries to decline invitation that's not pending  | ✅      |
| Non-invitee trying to accept invitation                 | ✅      |
| Invitee tries to accept invitation that's not pending   | ✅      |

---

### 🔐 **Permissions and Business Logic:**

* `accept` / `decline`: only valid for the **invitee**.
* `cancel`: only valid for the **admin** who sent it (must still be in the room).
* Invitations must be in `pending` status to be acted upon.
* Room must be active and exist.

---

### 📌 Notes:

* Ensures strong security boundaries for invitation lifecycles.
* Provides robust user feedback and prevents abuse or duplicate states.
* Ready for frontend integration: simple toggleable UI for each action.
